### PR TITLE
title and position of a chord can be provided as part of the chord

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ new SVGuitarChord('#some-selector')
         barres: [
           { fromString: 5, toString: 1, fret: 1, text: '1', color: '#0F0', textColor: '#F00' },
         ],
+
+        // title of the chart (optional)
+        title: 'F# minor',
+
+        // position (defaults to 1)
+        position: 2,
       })
       .configure({
           // Customizations (all optional, defaults shown)
@@ -117,7 +123,7 @@ new SVGuitarChord('#some-selector')
            */
           frets: 4,
           /**
-           * The starting fret (first fret is 1)
+           * Default position if no positon is provided (first fret is 1)
            */
           position: 1,
         
@@ -178,7 +184,7 @@ new SVGuitarChord('#some-selector')
           fontFamily: 'Arial, "Helvetica Neue", Helvetica, sans-serif',
         
           /**
-           * The title of the chart. Optional
+           * Default title of the chart if no title is provided
            */
           title: 'F# minor',
         

--- a/src/svguitar.test.ts
+++ b/src/svguitar.test.ts
@@ -284,6 +284,36 @@ describe('SVGuitarChord', () => {
     saveSvg('with title', container.outerHTML)
   })
 
+  it('Should render a title provided as part of the chord', () => {
+    svguitar
+      .configure({
+        title: 'DO NOT RENDER THIS',
+      })
+      .chord({
+        fingers: [],
+        barres: [],
+        title: 'title from chord',
+      })
+      .draw()
+
+    saveSvg('title from chord', container.outerHTML)
+  })
+
+  it('Should render the position provided as part of the chord', () => {
+    svguitar
+      .configure({
+        position: 999,
+      })
+      .chord({
+        fingers: [],
+        barres: [],
+        position: 3,
+      })
+      .draw()
+
+    saveSvg('position from chord', container.outerHTML)
+  })
+
   it('Should render a very long title nicely', () => {
     svguitar
       .configure({


### PR DESCRIPTION
Before this change both title and positions were part of the svguitar configuration object. With
this change, the title and position can be provided in the chord object. If title and position are
provided in both configuration and chart, the position and title of the configuration will be
ignored. So with this change the title and position provided in the configuration will act as
defaults for all chords created with the configured instance.

Fixes #43 