### PR TITLE
fix(chord diagram): fix fret marker outside diagram

### DIFF
--- a/src/svguitar.ts
+++ b/src/svguitar.ts
@@ -1209,7 +1209,7 @@ export class SVGuitarChord {
           fret: fretMarker,
         } : fretMarker) as DoubleFretMarker | SingleFretMarker
 
-        if (fretMarkerOptions.fret > this.numFrets()) {
+        if (fretMarkerOptions.fret >= this.numFrets()) {
           // don't draw fret markers outside the chord diagram
           return;
         }


### PR DESCRIPTION
Fix error where a fret marker would be rendered
outside the chord diagram if it followed
immediately after the last fret.