### PR TITLE
feat: render chord diagrams to an SVG string without a DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,67 @@ chart
   .draw()
 ```
 
+## Rendering without a browser (Node.js)
+
+SVGuitar can render chord charts to a plain SVG string without a DOM, which is useful for
+generating `.svg` files from a script. Pass no container to the constructor, call `draw()`, and
+then read the result with `toSvg()`.
+
+Under the hood SVGuitar uses [svg.js](https://svgjs.dev), which needs a global `window`/`document`
+to be registered. In Node this is provided by [`svgdom`](https://github.com/svgdotjs/svgdom)
+(already a dependency of SVGuitar). You need to register it once before rendering. Text layout
+depends on real font metrics, so a font also has to be provided — SVGuitar ships
+`OpenSans-Regular.ttf` for this purpose, but you can use any TTF.
+
+```javascript
+const fs = require('fs')
+const path = require('path')
+const { registerWindow } = require('@svgdotjs/svg.js')
+const svgdom = require('svgdom')
+const { SVGuitarChord } = require('svguitar')
+
+// point svgdom at a font and register a headless window (do this once)
+const fontDir = path.dirname(require.resolve('svguitar/fonts/OpenSans-Regular.ttf'))
+svgdom
+  .setFontDir(fontDir)
+  .setFontFamilyMappings({
+    // map every family your charts use to an available font file
+    Arial: 'OpenSans-Regular.ttf',
+    'Open Sans': 'OpenSans-Regular.ttf',
+  })
+  .preloadFonts()
+
+const window = svgdom.createSVGWindow()
+registerWindow(window, window.document)
+
+// render without a container
+const chart = new SVGuitarChord()
+chart
+  .configure({ title: 'Fm' })
+  .chord({
+    fingers: [
+      [6, 1],
+      [5, 3],
+      [4, 3],
+      [3, 1],
+      [2, 1],
+      [1, 1],
+    ],
+    barres: [{ fromString: 6, toString: 1, fret: 1 }],
+    position: 1,
+  })
+  .draw()
+
+fs.writeFileSync('Fm.svg', chart.toSvg())
+```
+
+Notes:
+
+- Metrics come from the bundled Open Sans, not the browser default (Arial), so text sizing is
+  close but not pixel-identical. Provide your own font mapping for exact results.
+- `toSvg()` also works in the browser, with or without a container.
+- The `handdrawn` style is **not** supported in headless mode yet (it still requires a DOM).
+
 ## Usage
 
 The SVG charts are highly customizable.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "module": "dist/svguitar.es5.js",
   "typings": "dist/types/svguitar.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "fonts/OpenSans-Regular.ttf"
   ],
   "author": "Raphael Voellmy <r.voellmy@gmail.com>",
   "repository": {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -20,7 +20,7 @@ export interface GraphcisElement {
 }
 
 export abstract class Renderer {
-  protected constructor(protected container: QuerySelector | HTMLElement) {}
+  protected constructor(protected container?: QuerySelector | HTMLElement) {}
 
   abstract line(
     x1: number,
@@ -37,6 +37,13 @@ export abstract class Renderer {
   abstract clear(): void
 
   abstract remove(): void
+
+  /**
+   * Serialize the current state of the diagram to an SVG string. The returned string is a
+   * standalone `<svg>` document (including the `xmlns` attribute) and can be written to a file
+   * or used without ever attaching it to the DOM.
+   */
+  abstract toSvgString(): string
 
   abstract background(color: string): void
 

--- a/src/renderer/roughjs/roughjs-renderer.ts
+++ b/src/renderer/roughjs/roughjs-renderer.ts
@@ -27,8 +27,15 @@ export class RoughJsRenderer extends Renderer {
 
   private svgNode: SVGSVGElement
 
-  constructor(container: QuerySelector | HTMLElement) {
+  constructor(container?: QuerySelector | HTMLElement) {
     super(container)
+
+    if (!container) {
+      throw new Error(
+        'The handdrawn chord diagram style requires a container element and is not supported ' +
+          'in headless mode yet. Use the default style to render without a DOM.',
+      )
+    }
 
     // initialize the container
     if (container instanceof HTMLElement) {
@@ -148,6 +155,16 @@ export class RoughJsRenderer extends Renderer {
 
   remove(): void {
     this.svgNode.remove()
+  }
+
+  toSvgString(): string {
+    const svg = this.svgNode.outerHTML
+
+    if (svg.includes('xmlns=')) {
+      return svg
+    }
+
+    return svg.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"')
   }
 
   line(

--- a/src/renderer/svgjs/svg-js-renderer.ts
+++ b/src/renderer/svgjs/svg-js-renderer.ts
@@ -5,14 +5,18 @@ import { constants } from '../../constants'
 export class SvgJsRenderer extends Renderer {
   private svg: Container
 
-  constructor(container: QuerySelector | HTMLElement) {
+  constructor(container?: QuerySelector | HTMLElement) {
     super(container)
 
     // initialize the SVG
     const { width } = constants
     const height = 0
 
-    this.svg = SVG().addTo(container)
+    // When no container is given the SVG is kept detached from the DOM. It can still be rendered
+    // and then exported via `toSvgString()`. This is the "headless" use case (e.g. generating SVG
+    // files in a Node.js script). Text measurement still works because svg.js uses its own
+    // internal helper element for that.
+    this.svg = container ? SVG().addTo(container) : SVG()
 
     this.svg.attr('preserveAspectRatio', 'xMidYMid meet').viewbox(0, 0, width, height)
   }
@@ -42,6 +46,19 @@ export class SvgJsRenderer extends Renderer {
 
   remove(): void {
     this.svg.remove()
+  }
+
+  toSvgString(): string {
+    const svg = this.svg.svg()
+
+    // svg.js only adds the `xmlns` attribute automatically when the SVG is attached to a real
+    // document. For the detached / headless case we add it here so the result is a valid
+    // standalone SVG document.
+    if (svg.includes('xmlns=')) {
+      return svg
+    }
+
+    return svg.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"')
   }
 
   background(color: string): void {

--- a/src/svguitar.ts
+++ b/src/svguitar.ts
@@ -557,7 +557,14 @@ export class SVGuitarChord {
 
   private chordInternal: Chord = { fingers: [], barres: [] }
 
-  constructor(private container: QuerySelector | HTMLElement) {
+  /**
+   * @param container The element into which the chord diagram is rendered. This can either be a
+   * CSS selector or a DOM element. If omitted, the diagram is rendered detached from the DOM and
+   * can be exported as a string with {@link toSvg}. This is useful for generating SVG files in a
+   * Node.js script without a browser. Note that the detached mode is only supported for the
+   * default (`normal`) chord diagram style.
+   */
+  constructor(private container?: QuerySelector | HTMLElement) {
     // apply plugins
     // https://stackoverflow.com/a/16345172
     const classConstructor = this.constructor as typeof SVGuitarChord
@@ -1549,6 +1556,17 @@ export class SVGuitarChord {
     }
 
     return width + titleBottomMargin
+  }
+
+  /**
+   * Export the current chord diagram as an SVG string. Call this after {@link draw}.
+   *
+   * The returned string is a standalone `<svg>` document (including the `xmlns` attribute), so it
+   * can be written directly to a `.svg` file. This works both in the browser and in a headless
+   * environment (see the constructor documentation).
+   */
+  toSvg(): string {
+    return this.renderer.toSvgString()
   }
 
   clear(): void {

--- a/test/svguitar.test.ts
+++ b/test/svguitar.test.ts
@@ -1,5 +1,6 @@
 import {
   BarreChordStyle,
+  ChordStyle,
   FretLabelPosition,
   Orientation,
   Shape,
@@ -1287,5 +1288,62 @@ describe('SVGuitarChord', () => {
     } else {
       expect(() => svguitar.configure({ [setting]: value })).toThrow()
     }
+  })
+
+  describe('SVG string export', () => {
+    it('Should return the rendered diagram as an SVG string via toSvg()', () => {
+      svguitar
+        .chord({
+          fingers: [
+            [1, 2, '1'],
+            [2, 1, '2'],
+            [3, 3, '3'],
+          ],
+          barres: [],
+        })
+        .configure({ title: 'Foo' })
+        .draw()
+
+      const svg = svguitar.toSvg()
+
+      expect(typeof svg).toBe('string')
+      expect(svg).toMatch(/^<svg/)
+      expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"')
+      expect(svg).toContain('class="title"')
+      expect(svg).toContain('</svg>')
+    })
+
+    it('Should render and export without a container (headless mode)', () => {
+      const headless = new SVGuitarChord()
+
+      const dimensions = headless
+        .chord({
+          fingers: [
+            [1, 2, '1'],
+            [2, 1, '2'],
+          ],
+          barres: [{ fromString: 5, toString: 1, fret: 1 }],
+        })
+        .configure({ title: 'Headless', tuning: ['E', 'A', 'D', 'G', 'B', 'E'] })
+        .draw()
+
+      expect(dimensions.width).toBeGreaterThan(0)
+      expect(dimensions.height).toBeGreaterThan(0)
+
+      const svg = headless.toSvg()
+
+      expect(svg).toMatch(/^<svg/)
+      expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"')
+      expect(svg).toContain('class="title"')
+      expect(svg).toContain('Headless')
+
+      saveSvg('headless chord', svg)
+    })
+
+    it('Should not support the handdrawn style without a container', () => {
+      const headless = new SVGuitarChord()
+
+      expect(() => headless.configure({ style: ChordStyle.handdrawn }).draw()).toThrow(/headless/i)
+    })
   })
 })


### PR DESCRIPTION
Closes #142 (and effectively #87).

## What

Adds a way to get the rendered chord diagram back as a plain SVG string, and to render entirely without a DOM element — useful for generating `.svg` files from a Node.js script.

```js
const chart = new SVGuitarChord()          // no container
chart.configure({ title: 'Fm' }).chord({ /* ... */ }).draw()
fs.writeFileSync('Fm.svg', chart.toSvg())
```

## Changes

| File | Change |
|---|---|
| `src/svguitar.ts` | `constructor(container?)` is now optional; new `toSvg(): string` |
| `src/renderer/renderer.ts` | new abstract `toSvgString()`; `container?` optional |
| `src/renderer/svgjs/svg-js-renderer.ts` | renders detached (`SVG()` without `addTo`) when no container is given; `toSvgString()` serializes via svg.js `.svg()` and injects the `xmlns` attribute that svg.js only adds automatically for attached SVGs |
| `src/renderer/roughjs/roughjs-renderer.ts` | implements `toSvgString()`; throws a clear error when constructed headless (the `handdrawn` style still requires a DOM) |
| `package.json` | ships `fonts/OpenSans-Regular.ttf` for svgdom text metrics |
| `README.md` | new "Rendering without a browser (Node.js)" section with a full recipe |
| `test/svguitar.test.ts` | tests for `toSvg()`, headless round-trip, and the handdrawn-headless rejection |

## Notes

- **Non-breaking**: `draw()` is unchanged and the container-based API is unchanged. `container` just became optional and `toSvg()` is additive.
- **Browser bundle is untouched**: `src/` never imports `svgdom`; verified `svgdom`/`fontkit` do not appear in `dist/svguitar.umd.js` or `dist/svguitar.es5.js`.
- Headless text metrics come from the bundled Open Sans, not Arial, so sizing is close but not pixel-identical; users can map their own fonts via svgdom.
- `handdrawn` headless support is intentionally out of scope here — the renderer throws a helpful error and the README documents the limitation. Worth a follow-up.

## Verification

- `yarn test` — all 72 tests pass, coverage thresholds met
- `yarn build` (`tsc` + `rollup`) — clean
- Confirmed `svgdom` absent from both dist bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)